### PR TITLE
Add p11 review workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Skills for Git workflows, code review processes, team coordination, and project 
 
 **Common use cases**: Version control automation, pull request management, code review, team synchronization, project planning
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [rarexlabs/p11-public](https://github.com/rarexlabs/p11-public) - Agent-to-human review workflows for shareable docs, comments, replies, and revisions across Codex and Claude Code.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -168,7 +168,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：版本控制自動化、Pull Request 管理、程式碼審查、團隊同步、專案規劃
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [rarexlabs/p11-public](https://github.com/rarexlabs/p11-public) - 適用於 Codex 與 Claude Code 的 agent-to-human 審閱流程，可建立可分享文件、收集評論、回覆並修訂。
 
 ---
 


### PR DESCRIPTION
Adds p11, an agent-to-human review workflow for Codex and Claude Code. p11 lets agents create shareable docs, collect human comments, then reply and revise through p11 skills.\n\nValidation:\n- Verified the linked repo is public and includes SKILL.md discovery plus Codex and Claude Code install paths.\n- Updated both English and Chinese README entries.