### PR TITLE
Add before-you-build Codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Skills for brand management, competitive analysis, domain research, internal com
 
 **Common use cases**: Brand guidelines enforcement, competitor research, content strategy, domain name ideation, internal announcements
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [Before You Build Skill](https://github.com/bin1874/before-you-build-skill) - Reviews product and feature risk before AI coding agents start implementation.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -128,7 +128,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：品牌指南執行、競爭對手研究、內容策略、域名創意發想、內部公告
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [Before You Build Skill](https://github.com/bin1874/before-you-build-skill)：在 AI coding agent 開始實作前，檢查產品與功能風險。
 
 ---
 


### PR DESCRIPTION
Adds a Codex skill for reviewing product and feature risk before an AI coding agent starts implementation.

The skill fits the business_marketing category and helps agents pause before coding to check demand, distribution, pricing, retention, trust, and workflow assumptions.

Source project: https://github.com/bin1874/before-you-build-skill