### PR TITLE
docs: add NotFair marketing skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This repository is not a package registry, a host for community skill files, a s
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — Turns authorized application source code into runnable Function, MCP tool, workflow Skill, and offline-test packages, with separate flow and source review skills. `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [CreatorSkills](https://github.com/calebvbi/creator-skills-samples) — Guides agents through content-creator workflows for YouTube scripting, thumbnail concepts, SEO, and audience personas. `Type: Collection` · `Platforms: Cross-platform`
+- [NotFair](https://github.com/nowork-studio/notfair-plugin) — Guides agents through SEO, GEO, paid-media, and analytics workflows using live marketing data and approval-gated changes. `Type: Collection` · `Platforms: Cross-platform`
 - [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — Routes coding agents through 14 skills for planning, composing, editing, generating, and assembling videos. `Type: Collection` · `Platforms: Codex, Claude Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — A multi-domain collection covering agent orchestration, code review, evaluation, product, design, and growth workflows. `Type: Collection` · `Platforms: Cross-platform`
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -66,6 +66,7 @@
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — 將獲授權的應用程式原始碼轉換為可執行的 Function、MCP Tool、工作流程 Skill 與離線測試套件，並提供獨立的流程與原始碼審查 Skill。 `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [CreatorSkills](https://github.com/calebvbi/creator-skills-samples) — 引導 Agent 執行 YouTube 腳本撰寫、縮圖構思、SEO 與受眾輪廓等內容創作者工作流程。 `Type: Collection` · `Platforms: Cross-platform`
+- [NotFair](https://github.com/nowork-studio/notfair-plugin) — 引導 Agent 運用即時行銷資料執行 SEO、GEO、付費廣告與分析工作流程，並在變更前取得核准。 `Type: Collection` · `Platforms: Cross-platform`
 - [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — 透過 14 個 Skill 引導程式設計 Agent 規劃、組合、編輯、生成及組裝影片。 `Type: Collection` · `Platforms: Codex, Claude Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — 涵蓋 Agent 編排、程式碼審查、評估、產品、設計與成長工作流程的多領域集合。 `Type: Collection` · `Platforms: Cross-platform`
 


### PR DESCRIPTION
Adds NotFair to **Skill Collections** in both `README.md` and `README_ZH.md`. NotFair provides open-source Agent Skills for SEO, GEO, paid-media, and analytics workflows using live marketing data and approval-gated changes.

The entries link to the canonical [notfair-plugin repository](https://github.com/nowork-studio/notfair-plugin), which documents installation, usage, external services, permissions, and support for multiple agent hosts. Its implementation is MIT licensed.

Validation:
- Only the two top-level READMEs change, with one alphabetized entry each.
- Names, URLs, `Type: Collection`, and `Platforms: Cross-platform` metadata match across both languages.
- No skill implementations or generated assets are copied into this repository.
- The PR contains one GitHub-verified commit based on the current default branch.
- Whitespace validation passes.

Affiliation: I am contributing on behalf of NotFair. The hosted NotFair MCP service is a commercial offering; the linked skill collection is open source.
