### PR TITLE
docs: add agent-skill-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Skills for file organization, task management, workflow automation, and producti
 
 **Common use cases**: File system organization, invoice processing, task tracking, automation setup, workflow optimization
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [agent-skill-groups](https://github.com/go165/agent-skill-groups) - Scenario-profile manager for local Agent Skills. Switch Codex, Claude Code, OpenCode, and generic `SKILL.md` folders between lean core and task-specific groups with JSON status, backups, and memory snippets.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -158,7 +158,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：檔案系統組織、發票處理、任務追蹤、自動化設定、工作流程最佳化
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [agent-skill-groups](https://github.com/go165/agent-skill-groups)：本機 Agent Skills 場景 profile 管理器。可在 Codex、Claude Code、OpenCode 和通用 `SKILL.md` 目錄之間切換精簡 core 與任務專用分組，並提供 JSON 狀態、備份和記憶片段。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add agent-skill-groups to Productivity & Organization
- Add the matching Traditional Chinese README entry

## Why
agent-skill-groups is a scenario-profile manager for local Agent Skills across Codex, Claude Code, OpenCode, and generic SKILL.md roots. It provides JSON status, backups, memory snippets, and current-session loading/profile switching workflows.