### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) - Use [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway for API integration, model routing, and media generation workflows.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,7 +108,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) - 使用 [routerbase](https://routerbase.com/) 作為 OpenAI 相容網關，處理 API 整合、模型路由和媒體生成工作流程。
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `routerbase-agent-skills` to the Development & Code Tools section.
- Keep the English and Chinese README entries aligned.

## Why
The repository contains reusable Agent Skills for using [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway for API integration, model routing, and media generation workflows.

## Validation
- Confirmed both README files contain one `routerbase` anchor link to `https://routerbase.com/`.
- Ran a static scan for common secret patterns and private contact information; only the expected RouterBase links were added.
