### PR TITLE
Add Tree Ring Memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [tree-ring-memory](https://github.com/TerminallyLazy/Tree-Ring-Memory/tree/main/skills/tree-ring-memory) - Local-first agent memory lifecycle skill for durable recall, forgetting, audit, evidence capture, and Rust CLI usage.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,7 +108,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [tree-ring-memory](https://github.com/TerminallyLazy/Tree-Ring-Memory/tree/main/skills/tree-ring-memory) - 本地優先的 Agent 記憶生命週期技能，支援持久回憶、遺忘、稽核、證據記錄與 Rust CLI 使用。
 
 ---
 


### PR DESCRIPTION
Adds Tree Ring Memory to the Development & Code Tools category in both English and Chinese READMEs.\n\nTree Ring Memory is a local-first agent memory lifecycle skill for durable recall, forgetting, audit, evidence capture, and Rust CLI usage. The linked folder contains the canonical SKILL.md package rather than duplicating the skill contents here.\n\nValidation performed:\n- Checked existing PRs and issues for tree-ring-memory duplicates\n- Searched README.md and README_ZH.md for existing Tree Ring Memory entries\n- Confirmed the public skill folder URL returns HTTP 200\n- Ran git diff --check\n\nDisclosure: I am affiliated with Tree Ring Memory.