### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,7 +108,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
 
 ---
 


### PR DESCRIPTION
## What changed

Added UIZZE anti-ui-slop to the Development & Code Tools category in both the English and Traditional Chinese indexes.

## Why

The instruction-only skill works across Codex, Claude Code, and Cursor. It uses UIZZE’s free 800,000+ screen catalogue workflow to create product-specific design decisions and enforce a pre-ship finish gate, with the optional full MCP at https://uizze.com.

Disclosure: I maintain UIZZE.