### PR TITLE
Use the UIZZE organization source

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
-- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. The free MIT Skill creates a product-specific design contract and pre-ship finish gate; the optional UIZZE MCP adds live search across 800,000+ real web and iOS screens at [uizze.com](https://uizze.com).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
-- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,7 +108,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
-- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -108,7 +108,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
-- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。免費且採 MIT 授權的 Skill 建立產品專屬設計規格，並在發布前執行完成度檢查；可選的 UIZZE MCP 在 [uizze.com](https://uizze.com) 提供 800,000+ 個真實 Web 與 iOS 畫面的即時搜尋。
 
 ---
 


### PR DESCRIPTION
UIZZE moved to its dedicated GitHub organization after the bilingual listing merged. This focused follow-up updates the English and Chinese source links from the redirected personal repository to canonical `uizze/uizze`; the existing plain `https://uizze.com` links and descriptions are unchanged.

Affiliation: I maintain UIZZE.