### PR TITLE
Add wiki to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Skills for file organization, task management, workflow automation, and producti
 
 **Common use cases**: File system organization, invoice processing, task tracking, automation setup, workflow optimization
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) - Indexed knowledge bases with command-line tools for agents.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -158,7 +158,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：檔案系統組織、發票處理、任務追蹤、自動化設定、工作流程最佳化
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) - 為 Agent 提供具索引的知識庫與命令列工具。
 
 ---
 


### PR DESCRIPTION
## What changed

- Added [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) to **Productivity & Organization** in the English index.
- Added the corresponding entry to the Traditional Chinese index.

## Why

wiki packages an installable skill and command-line workflow for building, indexing, searching, reading, and maintaining Markdown knowledge bases with compatible coding agents.

## Validation

- Confirmed the skill link resolves
- Confirmed the entry is not already listed
- Updated both language indexes
- Ran `git diff --check`

Disclosure: I'm affiliated with the project.