### PR TITLE
Add OratorDeck to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Skills for image generation, video processing, GIF creation, design work, and vi
 
 **Common use cases**: Image enhancement, video downloading, animation creation, visual design, media optimization
 
+- [OratorDeck](https://github.com/yuminhhuang/OratorDeck/tree/main/skills/oratordeck) - Prompt-as-Slide authoring workflow for generating aligned slide images and synchronized speaker notes, with reproducible asset audits and an optional handoff to a narrated-video pipeline.
 - [runapi-cli-skill](https://github.com/runapi-ai/cli-skill) - Run AI image, video, music/audio, and LLM model jobs from agent workflows through RunAPI.
 
 ---

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -148,6 +148,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：圖像增強、影片下載、動畫創建、視覺設計、媒體最佳化
 
+- [OratorDeck](https://github.com/yuminhhuang/OratorDeck/tree/main/skills/oratordeck)：以 Prompt-as-Slide 工作流程，從每頁一份權威 Markdown prompt 產生相互一致的投影片圖片與同步講稿，並提供可重現的資產稽核及可選的旁白影片流程銜接。
 - [runapi-cli-skill](https://github.com/runapi-ai/cli-skill)：透過 RunAPI 在 Agent 工作流程中執行 AI 圖像、影片、音樂/音訊和 LLM 模型任務。
 
 ---


### PR DESCRIPTION
## What changed

- Added the OratorDeck Prompt-as-Slide authoring skill to **Creative & Media**
  in the English index.
- Added the corresponding Traditional Chinese entry.

## Why it fits

OratorDeck packages an installable `SKILL.md` workflow that treats one
self-contained Markdown prompt as the authoritative source for each slide. The
skill guides an agent through generating aligned 16:9 slide images and
synchronized speaker notes, then runs bundled deterministic audits over prompt,
image, and anchor coverage.

The skill is usable independently of OratorDeck's optional GPU media pipeline
and has no Voicebox, Whisper, OCR, FFmpeg, or CUDA requirement.

## Validation

- Confirmed the linked skill is publicly reachable
- Confirmed OratorDeck is not already listed
- Updated both language indexes
- Confirmed exactly one entry exists in each index
- Ran `git diff --check`

Disclosure: I maintain OratorDeck.
