### PR TITLE
Add essay-writer to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Skills for content writing, editing, meeting analysis, article extraction, resea
 
 **Common use cases**: Content drafting, research synthesis, meeting insights, writing improvement, citation management
 
-- TBD: Skill list for this category (contributors can add entries here)
+- [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) - Plans, drafts, researches, edits, and reviews essays while preserving voice and evidence; also reports probable AI-writing signals without claiming authorship.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -138,7 +138,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 
 **常見使用場景**：內容草擬、研究綜合、會議洞察、寫作改進、引用管理
 
-- TBD：此分類技能清單（貢獻者可在此新增條目）
+- [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) - 規劃、撰寫、研究、編輯與審閱文章，同時保留作者語氣與證據，並在不判定作者身分的前提下分析可能的 AI 寫作訊號。
 
 ---
 


### PR DESCRIPTION
## Summary

- add the external `essay-writer` skill to Communication & Writing;
- add matching English and Traditional Chinese entries;
- link directly to the public skill folder.

## Why it fits

The skill plans, drafts, researches, edits and reviews essays while preserving evidence and voice. Its optional AI-writing analysis reports evidence, counterevidence and uncertainty rather than claiming proof of authorship.

## Validation

- the public skill link returns successfully;
- the repository contains a versioned public beta and MIT licence;
- both README changes pass `git diff --check`.
