### PR TITLE
Add overhaul-ui (frontend design + specialist-skill coordination)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
 - [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
+- [overhaul-ui](https://github.com/ShadowFull12/overhaul-ui) - Frontend design skill with 28 commands and 7 offline WCAG/OKLCH/slop-detection scripts; detects and defers to specialist design skills already installed.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -109,6 +109,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
 - [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
+- [overhaul-ui](https://github.com/ShadowFull12/overhaul-ui) - 前端設計技能，包含 28 個命令與 7 個離線 WCAG/OKLCH/slop 檢測腳本；可自動檢測並協調已安裝的專業設計技能。
 
 ---
 

--- a/skills/claude_code/README.md
+++ b/skills/claude_code/README.md
@@ -38,10 +38,16 @@ skills/claude_code/
 ├── creative_media/
 ├── data_analysis/
 ├── development_code_tools/
+│   └── overhaul_ui/
 ├── document_processing/
 ├── productivity_organization/
 └── security_systems/
 ```
+
+## Available Skills Index
+
+### Development & Code Tools
+- [overhaul-ui](./development_code_tools/overhaul_ui/SKILL.md) - Frontend design skill with 28 commands and 7 offline WCAG/OKLCH/slop-detection scripts; detects and defers to specialist design skills already installed.
 
 Suggested naming convention:
 - Skill folder: `snake_case` (example: `pdf_to_markdown_converter`)

--- a/skills/claude_code/development_code_tools/overhaul_ui/SKILL.md
+++ b/skills/claude_code/development_code_tools/overhaul_ui/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: overhaul-ui
+description: Frontend design skill with 28 commands, WCAG 2.2/OKLCH/motion scripts, and coordination logic that detects and defers to specialist design skills. Use for UI audits, redesigns, accessibility checks, and anti-AI-slop craft.
+---
+
+# overhaul-ui
+
+**Platforms:** Claude Code | Codex | Cursor | Antigravity | Gemini CLI | Windsurf | OpenCode | Cline | Roo | Amp
+**Tags:** frontend-design, ui-ux, anti-slop, wcag-2-2, oklch-color, motion-linting, design-systems
+**Use cases:** UI redesigns, accessibility hardening, design system tokens, anti-AI-slop audits, multi-skill coordination
+
+## Objective
+
+Give AI coding agents comprehensive frontend design judgment and real measurement tools (WCAG 2.2 contrast in OKLCH, motion anti-pattern linting, 35 AI-slop rules), while automatically detecting and deferring to installed specialist design skills.
+
+## Inputs
+
+- **Task/Prompt**: UI design, redesign, token creation, or audit request.
+- **Codebase**: React, Vue, Svelte, Astro, React Native, HTML/CSS frontend code.
+- **Installed Skills**: Auto-detected companion design skills (e.g. animation, taste skills).
+
+## Outputs
+
+- **Redesigned/Styled UI**: Component code adhering to anti-slop craft and hard visual boundaries.
+- **Design Tokens**: Structured token definitions (OKLCH color ramps, spacing scales, typography scales).
+- **Audit Reports**: Real computed metrics for WCAG 2.2 contrast, motion anti-patterns, and slop rules.
+
+## Workflow
+
+1. **Stack & Companion Detection**: Identifies framework/CSS setup and checks for existing specialist skills.
+2. **Command Routing**: Maps user request to 1 of 28 specialized command workflows.
+3. **Execution & Measurement**: Runs zero-dependency Node scripts for contrast, color math, and static linting.
+4. **Specialist Deferral**: Hands off specific sub-tasks (e.g. specialized motion philosophy) if companion skills are present.
+5. **Quality Gating**: Evaluates output against a pre-delivery checklist before presenting to the user.
+
+## Constraints & Guardrails
+
+- **Scope**: Frontend only — strictly out of scope for backend APIs, database schemas, or infrastructure.
+- **Dependencies**: Zero runtime dependencies. Runs offline.
+- **Honest Metrics**: Reports static a11y coverage limits (~30-40% of real WCAG criteria) explicitly without overclaiming compliance.
+
+## Examples
+
+### Example 1: UI Slop Audit
+
+**Input:**
+```bash
+overhaul-ui scan
+```
+
+**Expected Output:**
+```text
+[overhaul-ui] Audit summary:
+- 3 WCAG 2.2 AA contrast failures detected (computed in OKLCH)
+- 2 motion anti-patterns flagged (ease-in transition on entrance element)
+- 4 AI-slop visual patterns identified (untinted neutral grey #888, purple-blue gradient header)
+```
+
+## Evaluation Checklist
+
+- [x] **Correctness**: Computes exact contrast ratios using OKLCH color math
+- [x] **Completeness**: Covers 17 reference disciplines and 8 surface playbooks
+- [x] **Safety**: Zero external runtime network calls; runs fully offline
+- [x] **Reproducibility**: Identical linting output across all 13 supported AI coding agents
+- [x] **Documentation**: Complete reference chapters and command specs included
+
+## References
+
+- [overhaul-ui Repository](https://github.com/ShadowFull12/overhaul-ui)
+- [W3C WCAG 2.2 Guidelines](https://www.w3.org/TR/WCAG22/)
+- [OKLCH Color Space Specification](https://oklch.com/)
+
+## Version History
+
+- **v1.0.0** (2026-07-28): Initial release with 28 commands, 17 reference domains, and 7 offline measurement scripts.


### PR DESCRIPTION
## Objective
Give AI coding agents design judgment for frontend UI work, and coordinate between already-installed specialist design skills instead of duplicating them.

## Inputs
A UI task or existing codebase (React, Vue, Svelte, Astro, React Native, and others).

## Outputs
Styled/redesigned UI, a design-system token file, or an audit report — routed through one of 28 command workflows depending on the request.

## Workflow
Detects the project's stack and any installed specialist skills, routes the request to the matching command, runs offline scripts (WCAG contrast, OKLCH palette generation, AI-slop/motion linting) where the task needs measurement rather than taste, and gates the result against a pre-delivery checklist before returning it.

## Constraints
Frontend only — explicitly out of scope for backend, infra or data work. Zero runtime dependencies. MIT licensed.

## Entry
- [overhaul-ui](https://github.com/ShadowFull12/overhaul-ui) - Frontend design skill with 28 commands and 7 offline WCAG/OKLCH/slop-detection scripts; detects and defers to specialist design skills already installed.

Drafted with AI assistance, reviewed by maintainer before submission.