### PR TITLE
docs: add Suede Creator Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Skills focused on programming, testing, debugging, code review, browser automati
 **Common use cases**: Code refactoring, test generation, debugging assistance, code review automation, web testing, build optimization
 
 - [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Stops Codex, Claude Code, Cursor, and compatible coding agents from shipping generic UI. Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to create a product-specific design contract and enforce a pre-ship finish gate. Full MCP at [uizze.com](https://uizze.com).
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - A 67-skill, MIT-licensed toolkit for Claude Code and Codex covering agent orchestration, Codex worker fleets, code review and ship gates, AI evaluation, product, design, and growth workflows.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -109,6 +109,7 @@ Skill 讓 AI Agent 能夠在不同平台和情境中，一致且可靠地執行�
 **常見使用場景**：程式碼重構、測試生成、除錯輔助、程式碼審查自動化、網頁測試、建構最佳化
 
 - [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - 防止 Codex、Claude Code、Cursor 與相容的程式設計 Agent 產出千篇一律的 UI。透過 UIZZE 免費的 800,000+ 真實 Web 與 iOS 畫面目錄建立產品專屬設計規格，並在發布前執行完成度檢查；完整 MCP 請見 [uizze.com](https://uizze.com)。
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 面向 Claude Code 與 Codex 的 67 個 MIT 授權 Skills，涵蓋多 Agent 編排、Codex 工作節點集群、程式碼審查與發布門檻、AI 評測、產品、設計和成長工作流程。
 
 ---
 


### PR DESCRIPTION
# Summary

- Add Suede Creator Skills to Development & Code Tools in both language files.
- Describe the verified 67-skill, MIT-licensed Claude Code and Codex collection in the repository's native format.

# Why

The listing gives readers a documented, actively maintained collection with distinct engineering and product workflow coverage.

# Testing

- git diff --check; source link resolved.
- Verified the public repository reports 67 skill folders and an MIT license.

# Scope

Documentation and catalog metadata only; no runtime behavior changes.

# Risks

The public skill count can change over time. The description reflects the source repository on 2026-08-03.

