### PR TITLE
docs: add OrkasVideoStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This repository is not a package registry, a host for community skill files, a s
 ### Skill Collections
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — Turns authorized application source code into runnable Function, MCP tool, workflow Skill, and offline-test packages, with separate flow and source review skills. `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — Routes coding agents through 14 skills for planning, composing, editing, generating, and assembling videos. `Type: Collection` · `Platforms: Codex, Claude Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — A multi-domain collection covering agent orchestration, code review, evaluation, product, design, and growth workflows. `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -63,6 +63,7 @@
 ### Skill Collections
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — 將獲授權的應用程式原始碼轉換為可執行的 Function、MCP Tool、工作流程 Skill 與離線測試套件，並提供獨立的流程與原始碼審查 Skill。 `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — 透過 14 個 Skill 引導程式設計 Agent 規劃、組合、編輯、生成及組裝影片。 `Type: Collection` · `Platforms: Codex, Claude Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — 涵蓋 Agent 編排、程式碼審查、評估、產品、設計與成長工作流程的多領域集合。 `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations


### PR DESCRIPTION
## Summary

- Adds OrkasVideoStudio to `Skill Collections` in both English and Chinese READMEs.
- Links directly to the canonical 14-skill collection directory.
- Keeps the visible name, URL, `Type`, and `Platforms` metadata identical and alphabetized in both files.

## Verification

- Confirmed 14 public `SKILL.md` implementations in the linked collection.
- Confirmed the upstream documentation, source-install workflow, Codex and Claude Code support, and MIT license.
- Confirmed the PR changes only `README.md` and `README_ZH.md`.
- `git diff --check` passes.
- The single commit is signed by GitHub and displays `Verified`.

## Affiliation

Submitted on behalf of the Orkas project; I am affiliated with OrkasVideoStudio.
