### PR TITLE
Add Code2Skill skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This repository is not a package registry, a host for community skill files, a s
 
 ### Skill Collections
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) — Turns authorized application source code into runnable Function, MCP tool, workflow Skill, and offline-test packages, with separate flow and source review skills. `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — A multi-domain collection covering agent orchestration, code review, evaluation, product, design, and growth workflows. `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -62,6 +62,7 @@
 
 ### Skill Collections
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) — 將獲授權的應用程式原始碼轉換為可執行的 Function、MCP Tool、工作流程 Skill 與離線測試套件，並提供獨立的流程與原始碼審查 Skill。 `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — 涵蓋 Agent 編排、程式碼審查、評估、產品、設計與成長工作流程的多領域集合。 `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations


### PR DESCRIPTION
## Summary

Adds Code2Skill to the Skill Collections section in both English and Traditional Chinese. Code2Skill contains three Agent Skills that generate and independently review runnable Function, MCP tool, workflow Skill, and offline-test packages from user-authorized application source code.

## Platform

Codex, Claude Code, and Kimi Code are documented by the upstream project.

## Disclosure

This is a self-nomination; I am the maintainer of Code2Skill.

## Validation

- Updated only README.md and README_ZH.md
- Name, URL, type, and platform metadata match in both files
- Both commits are GitHub Verified
- Confirmed there is no existing Code2Skill listing or pull request
- git diff --check passed