### PR TITLE
docs: add KnowSift

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repository is not a package registry, a host for community skill files, a s
 #### Data & Analysis
 
 - [credit-risk-model](https://github.com/W-Y-P/credit-risk-model) — Guides credit-risk model development, validation, reporting, and strategy analysis. `Type: Skill` · `Platforms: Cross-platform`
+- [KnowSift](https://github.com/nhppyqys/knowsift) — Compiles mixed research sources into certificate-backed knowledge documents that preserve evidence, scope, viewpoints, disputes, and rejected claims. `Type: Skill` · `Platforms: Codex, Claude Code`
 - [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — Routes X research, extraction, monitoring, and confirmation-gated publishing through REST, MCP, SDK, or webhook workflows. `Type: Skill` · `Platforms: Cross-platform`
 
 #### Communication & Writing

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -46,6 +46,7 @@
 #### 數據與分析
 
 - [credit-risk-model](https://github.com/W-Y-P/credit-risk-model) — 引導信用風險模型開發、驗證、報告與策略分析。 `Type: Skill` · `Platforms: Cross-platform`
+- [KnowSift](https://github.com/nhppyqys/knowsift) — 將混合研究來源編譯為由證書約束的分層知識文件，保留證據、適用範圍、觀點、爭議與被排除主張。 `Type: Skill` · `Platforms: Codex, Claude Code`
 - [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — 透過 REST、MCP、SDK 或 webhook 工作流程處理 X 研究、資料擷取、監測與需確認的發布操作。 `Type: Skill` · `Platforms: Cross-platform`
 
 #### 溝通與寫作


### PR DESCRIPTION
Adds KnowSift to the Data & Analysis section in both the English and Traditional Chinese directories.

Why it fits:
- Provides a directly usable SKILL.md and certificate-enforced Python runtime.
- Compiles mixed research sources into layered, traceable knowledge documents.
- Documents installation, usage, platform support, permissions, safety boundaries, and a real-world benchmark.
- Publicly available under the MIT License.
- Supports Codex and Claude Code.

Affiliation: I am the maintainer of KnowSift.

Checklist:
- [x] Only README.md and README_ZH.md changed
- [x] English and Chinese metadata match
- [x] Entry is alphabetized under Data & Analysis
- [x] Every commit is Verified
- [x] Canonical repository and license are public