### PR TITLE
docs: add SandBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This repository is not a package registry, a host for community skill files, a s
 ### Tooling & Integrations
 
 - [Agent QA](https://github.com/vostride/agent-qa) — Runs natural-language web and mobile QA workflows through a CLI, MCP server, and three evidence-oriented Agent Skills. `Type: CLI + MCP + Collection` · `Platforms: Codex, Agent Skills-compatible agents`
+- [SandBase](https://github.com/sandbaseai/cli) — Connects AI agents to unified model and tool APIs through a local CLI-managed MCP bridge and Agent Skill. `Type: CLI + MCP + Skill` · `Platforms: Cross-platform`
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) — Provides supervised X research, publishing, media, follower export, giveaway, and monitoring workflows. `Type: Plugin + Skill` · `Platforms: OpenClaw, Agent Skills-compatible agents`
 
 ## Using a Listed Project

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -70,6 +70,7 @@
 ### Tooling & Integrations
 
 - [Agent QA](https://github.com/vostride/agent-qa) — 透過 CLI、MCP 伺服器與三個以證據為導向的 Agent Skills，執行自然語言網頁與行動應用程式 QA 工作流程。 `Type: CLI + MCP + Collection` · `Platforms: Codex, Agent Skills-compatible agents`
+- [SandBase](https://github.com/sandbaseai/cli) — 透過本機 CLI 管理的 MCP 橋接器與 Agent Skill，讓 AI Agent 連接統一的模型與工具 API。 `Type: CLI + MCP + Skill` · `Platforms: Cross-platform`
 - [TweetClaw](https://github.com/Xquik-dev/tweetclaw) — 提供受控的 X 研究、發布、媒體、追蹤者匯出、抽獎與監測工作流程。 `Type: Plugin + Skill` · `Platforms: OpenClaw, Agent Skills-compatible agents`
 
 ## 使用收錄專案


### PR DESCRIPTION
Adds SandBase to Tooling & Integrations as a CLI-managed MCP bridge with an Agent Skill.

Eligibility evidence:
- Public Apache-2.0 implementation: https://github.com/sandbaseai/cli
- Directly usable Skill: https://github.com/sandbaseai/cli/tree/main/skills/sandbase
- Setup, permissions, external service, rollback, and supported clients are documented upstream
- The English and Traditional Chinese entries use identical name, URL, type, and platform metadata
- The single commit is GitHub-verified

Affiliation: I am submitting this on behalf of the SandBase maintainer organization. The description is factual and omits prices, version numbers, counts, star counts, and superlatives.