### PR TITLE
Add AgentBody X Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ This repository is not a package registry, a host for community skill files, a s
 
 #### Creative & Media
 
-- [runapi-cli-skill](https://github.com/runapi-ai/cli-skill) — Teaches agents to run image, video, audio, and language-model jobs through the RunAPI CLI. `Type: Skill` · `Platforms: Cross-platform`
+- [runapi-cli-skill](https://github.com/runapi-ai/cli-skill)
+- [agentbody-x-research](https://github.com/agentbody/skills/tree/main/skills/x-research) — Read-only X/Twitter search, trends, profile inspection, media, and replies via AgentBody API. `Type: Skill` · `Platforms: Cross-platform` — Teaches agents to run image, video, audio, and language-model jobs through the RunAPI CLI. `Type: Skill` · `Platforms: Cross-platform`
 
 #### Productivity & Organization
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -55,7 +55,8 @@
 
 #### 創意與媒體
 
-- [runapi-cli-skill](https://github.com/runapi-ai/cli-skill) — 教導 Agent 透過 RunAPI CLI 執行影像、影片、音訊與語言模型工作。 `Type: Skill` · `Platforms: Cross-platform`
+- [runapi-cli-skill](https://github.com/runapi-ai/cli-skill)
+- [agentbody-x-research](https://github.com/agentbody/skills/tree/main/skills/x-research) — 透過 AgentBody API 進行只讀 X/Twitter 搜索、趨勢、主頁、媒體和回覆。`Type: Skill` · `Platforms: Cross-platform` — 教導 Agent 透過 RunAPI CLI 執行影像、影片、音訊與語言模型工作。 `Type: Skill` · `Platforms: Cross-platform`
 
 #### 生產力與組織
 


### PR DESCRIPTION
Adds a new skill to both README.md and README_ZH.md under Creative & Media.

- Canonical source: https://github.com/agentbody/skills/tree/main/skills/x-research
- Read-only X/Twitter search, trends, profile inspection, media, and replies via AgentBody API
- MIT licensed, includes SKILL.md, Python client, API reference, and tests
- Affiliation: I maintain this skill