### PR TITLE
docs: add Agent Coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This repository is not a package registry, a host for community skill files, a s
 
 #### Productivity & Organization
 
+- [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) — Coordinates complex work through a resumable local dependency graph, declared write scopes, reconciliation before retries, and repeatable closeout checks. `Type: Skill` · `Platforms: Codex`
 - [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) — Creates and queries indexed Markdown knowledge bases with deterministic CLI support for agents. `Type: Skill` · `Platforms: Codex, Claude Code`
 
 ### Skill Collections

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -59,6 +59,7 @@
 
 #### 生產力與組織
 
+- [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) — 將複雜工作編排為可續接的本機相依圖，聲明寫入範圍，先核對結果不明的作業再重試，並於結案時重跑檢查。 `Type: Skill` · `Platforms: Codex`
 - [wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) — 透過具確定性行為的 CLI，建立並查詢已索引的 Markdown 知識庫。 `Type: Skill` · `Platforms: Codex, Claude Code`
 
 ### Skill Collections


### PR DESCRIPTION
## Summary

Adds Agent Coordinator to **Agent Skills → Productivity & Organization** in the English and Traditional Chinese directories.

Agent Coordinator is a directly usable Codex skill with a bundled local state owner. It records dependency-aware work, preserves progress across interruptions, reconciles uncertain work before retry, and runs authored checks at closeout. The linked repository documents installation, usage, Python 3.11+, local state, permissions, and the absence of third-party runtime packages.

## Contribution type

- [x] New listing
- [ ] Listing update, move, or removal
- [ ] Documentation or repository maintenance

## Project details

- Canonical source: https://github.com/alanhoff/agent-coordinator
- README section/category: Agent Skills → Productivity & Organization / 生產力與組織
- Type: Skill
- Platforms: Codex
- License: MIT
- Affiliation or commercial relationship: I maintain Agent Coordinator.
- Related taxonomy issue: N/A

## Checklist

### Listing changes

- [x] The source, working implementation, documentation, and license are public.
- [x] The link is canonical and points directly to the relevant skill or collection when it lives in a monorepo.
- [x] The type and platform claims are supported by upstream documentation.
- [x] The description is one concise, factual, neutral, and non-volatile sentence.
- [x] I searched for duplicate listings, issues, and pull requests.
- [x] This pull request covers one upstream project or one tightly related collection.
- [x] I updated both `README.md` and `README_ZH.md` with identical names, URLs, types, and platforms.
- [x] The entry is alphabetized within its subsection.
- [x] This listing pull request changes only `README.md` and `README_ZH.md`.
- [x] I did not add `SKILL.md`, scripts, copied skill folders, assets, or platform indexes.
- [x] I linked a prior issue if this introduces a new top-level category or type, or marked it `N/A` above.
- [x] I disclosed my affiliation or commercial relationship above.

### All pull requests

- [x] The changes are focused and the documentation renders correctly.
- [x] Every commit in this pull request displays **Verified** on GitHub.

## Validation

- The public source is current at `fb3d64688a9e1b7c02a114a14faac1219ec10f51`, with a passing main-branch CI run.
- `git diff --check` passes.
- The two entries have identical name, URL, type, and platform metadata and are placed before `wiki` in their matching subsections.
- GitHub reports every commit on this branch as cryptographically verified.

Only `README.md` and `README_ZH.md` are changed. I prepared this submission with Codex and reviewed both descriptions against the public source.
