### PR TITLE
docs: add publora-post-ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository is not a package registry, a host for community skill files, a s
 #### Communication & Writing
 
 - [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) — Plans, drafts, researches, edits, and reviews essays while preserving voice, evidence, and uncertainty. `Type: Skill` · `Platforms: Codex, Agent Skills-compatible agents`
+- [publora-post-ideas](https://github.com/publora-team/publora-post-ideas) — Offers a choice of angles for a social post, drafts the selected one, and can schedule it through Publora. `Type: Skill` · `Platforms: Claude Code, Agent Skills-compatible agents`
 
 #### Creative & Media
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -52,6 +52,7 @@
 #### 溝通與寫作
 
 - [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) — 規劃、起草、研究、編修與審閱文章，同時保留作者語氣、證據與不確定性。 `Type: Skill` · `Platforms: Codex, Agent Skills-compatible agents`
+- [publora-post-ideas](https://github.com/publora-team/publora-post-ideas) — 提供社群貼文的多個切入角度供選擇，撰寫選定的那一個，並可透過 Publora 排程發布。 `Type: Skill` · `Platforms: Claude Code, Agent Skills-compatible agents`
 
 #### 創意與媒體
 


### PR DESCRIPTION
## Summary

Adds one listing for `publora-post-ideas` under Agent Skills → Communication & Writing, in both READMEs. No other files are touched.

The skill changes what an agent does with an open-ended request like "write me a post": instead of returning one draft chosen on the first guess, it offers a choice of angles, asks which one, and then asks for the single fact that has to come from the user before drafting.

## Contribution type

- [x] New listing
- [ ] Listing update, move, or removal
- [ ] Documentation or repository maintenance

## Project details

- Canonical source: https://github.com/publora-team/publora-post-ideas
- README section/category: Agent Skills → Communication & Writing
- Type: `Skill`
- Platforms: Claude Code, Agent Skills-compatible agents
- License: MIT
- Affiliation or commercial relationship: I am the author of the skill. Publora, the optional service it can connect to for reading and scheduling posts, is the product I work on. The skill is usable without it and the listing description is written to be neutral.
- Related taxonomy issue: N/A

## Checklist

### Listing changes

- [x] The source, working implementation, documentation, and license are public.
- [x] The link is canonical and points directly to the relevant skill or collection when it lives in a monorepo.
- [x] The type and platform claims are supported by upstream documentation.
- [x] The description is one concise, factual, neutral, and non-volatile sentence.
- [x] I searched for duplicate listings, issues, and pull requests.
- [x] This pull request covers one upstream project or one tightly related collection.
- [x] I updated both `README.md` and `README_ZH.md` with identical names, URLs, types, and platforms.
- [x] The entry is alphabetized within its subsection.
- [x] This listing pull request changes only `README.md` and `README_ZH.md`.
- [x] I did not add `SKILL.md`, scripts, copied skill folders, assets, or platform indexes.
- [x] I linked a prior issue if this introduces a new top-level category or type, or marked it `N/A` above.
- [x] I disclosed my affiliation or commercial relationship above.

### All pull requests

- [x] The changes are focused and the documentation renders correctly.
- [x] Every commit in this pull request displays **Verified** on GitHub.

On platforms: I have run this in Claude Code. The skill is a plain `SKILL.md` with one reference file and no scripts or platform-specific behaviour, so I listed the other hosts as "Agent Skills-compatible agents" rather than naming ones I have not tested.
