### PR TITLE
docs: add ManualMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository is not a package registry, a host for community skill files, a s
 
 #### Development & Code
 
+- [ManualMode](https://github.com/itscloud0/manualmode-skill) — Reserves bounded tasks from real project work for manual coding practice and reports verification metadata to ManualMode. `Type: Skill` · `Platforms: Cross-platform`
 - [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) — Builds a product-specific UI design contract and applies a pre-ship finish gate using real interface references. `Type: Skill` · `Platforms: Cross-platform`
 
 #### Data & Analysis

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,6 +41,7 @@
 
 #### 開發與程式工具
 
+- [ManualMode](https://github.com/itscloud0/manualmode-skill) — 從實際專案工作中保留範圍明確的任務，供使用者手動練習編程，並向 ManualMode 回報驗證中繼資料。 `Type: Skill` · `Platforms: Cross-platform`
 - [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) — 根據真實介面參考建立產品專屬 UI 設計契約，並執行發布前完成度檢查。 `Type: Skill` · `Platforms: Cross-platform`
 
 #### 數據與分析


### PR DESCRIPTION
## Summary

Add ManualMode to Development & Code in both language versions. The skill lets a coding agent reserve a small task from real project work for the user to implement manually, then submit verification metadata to the hosted service.

## Contribution type

- [x] New listing
- [ ] Listing update, move, or removal
- [ ] Documentation or repository maintenance

## Project details

- Canonical source: https://github.com/itscloud0/manualmode-skill
- README section/category: Agent Skills / Development & Code
- Type: Skill
- Platforms: Cross-platform. The public SKILL.md documents Codex, Claude Code, Kimi, Cursor and other MCP clients; this is documented host support, not a claim that every client/version was separately tested for this PR.
- License: MIT for the static skill.
- Affiliation or commercial relationship: I build ManualMode. The skill uses the hosted ManualMode service and requires an account and pairing through its Projects page. The free tier includes one Project rep; Pro costs $20/month or $200/year. No subscription purchase is required to try that first rep.
- Related taxonomy issue: N/A.

Setup uses the application's complete prompt with the exact API environment and a one-time pairing code. The returned token belongs in the client's user-level secret store. The skill instructs the agent to send bounded metadata, not source, diffs, prompts, transcripts or raw command output. Its task reservation is an instruction boundary, not an OS sandbox. The browser coding gym is JavaScript-only; Project Mode operates in the user's local repository.

## Checklist

- [x] The source, working implementation, documentation, and license are public.
- [x] The link is canonical and points directly to the skill repository.
- [x] The type and platform claims are supported by upstream documentation.
- [x] The description is concise, factual, neutral, and non-volatile.
- [x] Searched both READMEs and repository issues/PRs for ManualMode; no duplicate found.
- [x] Covers one upstream project and updates only README.md and README_ZH.md.
- [x] Both entries have identical names, URLs, types and platforms; placement is alphabetical.
- [x] No implementation, scripts, copied skill folders, assets or indexes added here.
- [x] Uses existing taxonomy; affiliation and commercial dependency disclosed above.
- [x] Changes are focused; both Markdown entries use the repository's existing bullet format.
- [x] The single commit is signed and verified by GitHub.

Verification: anonymous HTTP 200 for the pinned v0.1.0 SKILL.md; public repository and MIT license checked; two-file diff contains one added entry per file. Listing prose and this submission were prepared with AI assistance and checked against the upstream source.
