### PR TITLE
docs: add Slashskills

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This repository is not a package registry, a host for community skill files, a s
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — Turns authorized application source code into runnable Function, MCP tool, workflow Skill, and offline-test packages, with separate flow and source review skills. `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [CreatorSkills](https://github.com/calebvbi/creator-skills-samples) — Guides agents through content-creator workflows for YouTube scripting, thumbnail concepts, SEO, and audience personas. `Type: Collection` · `Platforms: Cross-platform`
 - [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — Routes coding agents through 14 skills for planning, composing, editing, generating, and assembling videos. `Type: Collection` · `Platforms: Codex, Claude Code`
+- [Slashskills](https://github.com/tushaarmehtaa/tushar-skills) — Guides agents through software design, implementation, release checks, and documentation workflows. `Type: Collection` · `Platforms: Codex, Claude Code, Cursor`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — A multi-domain collection covering agent orchestration, code review, evaluation, product, design, and growth workflows. `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -68,6 +68,7 @@
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — 將獲授權的應用程式原始碼轉換為可執行的 Function、MCP Tool、工作流程 Skill 與離線測試套件，並提供獨立的流程與原始碼審查 Skill。 `Type: Collection` · `Platforms: Codex, Claude Code, Kimi Code`
 - [CreatorSkills](https://github.com/calebvbi/creator-skills-samples) — 引導 Agent 執行 YouTube 腳本撰寫、縮圖構思、SEO 與受眾輪廓等內容創作者工作流程。 `Type: Collection` · `Platforms: Cross-platform`
 - [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills) — 透過 14 個 Skill 引導程式設計 Agent 規劃、組合、編輯、生成及組裝影片。 `Type: Collection` · `Platforms: Codex, Claude Code`
+- [Slashskills](https://github.com/tushaarmehtaa/tushar-skills) — 引導 Agent 執行軟體設計、實作、發布檢查與文件撰寫工作流程。 `Type: Collection` · `Platforms: Codex, Claude Code, Cursor`
 - [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) — 涵蓋 Agent 編排、程式碼審查、評估、產品、設計與成長工作流程的多領域集合。 `Type: Collection` · `Platforms: Cross-platform`
 
 ### Tooling & Integrations


### PR DESCRIPTION
## Summary
Add Slashskills to Skill Collections, with matching English and Traditional Chinese entries. The collection provides directly installable SKILL.md workflows and bundled references for software work.

## Contribution type
- [x] New listing

## Project details
- Canonical source: https://github.com/tushaarmehtaa/tushar-skills
- README section/category: Skill Collections
- Type: Collection
- Platforms: Codex, Claude Code, Cursor
- License: MIT
- Affiliation: I maintain the upstream repository. Prepared with AI assistance.
- Related taxonomy issue: N/A

## Checklist
- [x] Public source, skill implementations, documentation, and license.
- [x] Canonical collection link; documented platform installation paths.
- [x] Neutral description without volatile counts or promotional claims.
- [x] Searched existing listings, issues, and open pull requests for duplicates.
- [x] One collection; only README.md and README_ZH.md changed.
- [x] Matching names, URLs, types, and platforms; translated description.
- [x] Alphabetical placement; no copied skill implementations.
- [x] Affiliation disclosed; existing category used.
- [x] Focused Markdown change.
- [x] Commit signature verified through GitHub before submission.

Validation: upstream repository/package checks and website tests pass. Runtime setup is documented; this is not a claim that every workflow has been evaluated end-to-end in every host.
