### PR TITLE
docs: add agent-architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository is not a package registry, a host for community skill files, a s
 
 #### Development & Code
 
+- [agent-architecture](https://github.com/Crabbb/agent-architecture) — Guides agent architecture discovery and evidence-based diagnosis, producing requirements, capability methods, tool and state contracts, diagrams, and acceptance criteria. `Type: Skill` · `Platforms: Codex, Claude Code`
 - [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) — Builds a product-specific UI design contract and applies a pre-ship finish gate using real interface references. `Type: Skill` · `Platforms: Cross-platform`
 
 #### Data & Analysis

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,6 +41,7 @@
 
 #### 開發與程式工具
 
+- [agent-architecture](https://github.com/Crabbb/agent-architecture) — 引導 Agent 架構需求探索與實證診斷，產出需求、能力方法、工具與狀態契約、架構圖及驗收準則。 `Type: Skill` · `Platforms: Codex, Claude Code`
 - [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) — 根據真實介面參考建立產品專屬 UI 設計契約，並執行發布前完成度檢查。 `Type: Skill` · `Platforms: Cross-platform`
 
 #### 數據與分析


### PR DESCRIPTION
## Summary

Adds agent-architecture under Development & Code in both READMEs. The skill guides requirements discovery for a new agent and evidence-based diagnosis of an existing one, with contracts and acceptance criteria for implementation handoff

## Contribution type

- [x] New listing
- [ ] Listing update, move, or removal
- [ ] Documentation or repository maintenance

## Project details

- Canonical source: https://github.com/Crabbb/agent-architecture
- README section/category: Agent Skills / Development & Code
- Type: Skill
- Platforms: Codex, Claude Code
- License: MIT
- Affiliation or commercial relationship: I am the author and maintainer
- Related taxonomy issue: N/A

The repository includes a directly usable SKILL.md, supporting references, installation instructions and synthetic design/diagnosis examples. The installable SKILL.md and all bundled references are now available in English. The original Russian instruction package is preserved separately; the walkthrough examples remain in Russian. Cross-language behavioral equivalence is not claimed

## Checklist

### Listing changes

- [x] The source, working implementation, documentation, and license are public.
- [x] The link is canonical and points directly to the relevant skill or collection when it lives in a monorepo.
- [x] The type and platform claims are supported by upstream documentation.
- [x] The description is one concise, factual, neutral, and non-volatile sentence.
- [x] I searched for duplicate listings, issues, and pull requests.
- [x] This pull request covers one upstream project or one tightly related collection.
- [x] I updated both `README.md` and `README_ZH.md` with identical names, URLs, types, and platforms.
- [x] The entry is alphabetized within its subsection.
- [x] This listing pull request changes only `README.md` and `README_ZH.md`.
- [x] I did not add `SKILL.md`, scripts, copied skill folders, assets, or platform indexes.
- [x] I linked a prior issue if this introduces a new top-level category or type, or marked it `N/A` above.
- [x] I disclosed my affiliation or commercial relationship above.

### All pull requests

- [x] The changes are focused and the documentation renders correctly.
- [x] Every commit in this pull request displays **Verified** on GitHub.
