### PR TITLE
docs: add Novel Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This repository is not a package registry, a host for community skill files, a s
 #### Communication & Writing
 
 - [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) — Plans, drafts, researches, edits, and reviews essays while preserving voice, evidence, and uncertainty. `Type: Skill` · `Platforms: Codex, Agent Skills-compatible agents`
+- [Novel Writing](https://github.com/wgwtest/novel-writing) — Guides fiction planning, drafting, and revision with viewpoint, scene-causality, dialogue, and style-preservation checks. `Type: Skill` · `Platforms: Codex`
 - [publora-post-ideas](https://github.com/publora-team/publora-post-ideas) — Offers a choice of angles for a social post, drafts the selected one, and can schedule it through Publora. `Type: Skill` · `Platforms: Claude Code, Agent Skills-compatible agents`
 
 #### Creative & Media

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -52,6 +52,7 @@
 #### 溝通與寫作
 
 - [essay-writer](https://github.com/shimellism-eng/essay-writer-editor/tree/main/skills/essay-writer) — 規劃、起草、研究、編修與審閱文章，同時保留作者語氣、證據與不確定性。 `Type: Skill` · `Platforms: Codex, Agent Skills-compatible agents`
+- [Novel Writing](https://github.com/wgwtest/novel-writing) — 指導小說規劃、起草與修訂，檢查人物視角、場景因果、對白及作者文風的保留。 `Type: Skill` · `Platforms: Codex`
 - [publora-post-ideas](https://github.com/publora-team/publora-post-ideas) — 提供社群貼文的多個切入角度供選擇，撰寫選定的那一個，並可透過 Publora 排程發布。 `Type: Skill` · `Platforms: Claude Code, Agent Skills-compatible agents`
 
 #### 創意與媒體


### PR DESCRIPTION
## Summary
Add Novel Writing to Communication & Writing in both READMEs. The skill focuses on fiction-specific viewpoint access, scene causality, dialogue behavior, and voice-preserving revision. Only two listing lines change.

## Contribution type
- [x] New listing

## Project details
- Canonical source: https://github.com/wgwtest/novel-writing
- README category: Agent Skills / Communication & Writing
- Type: Skill
- Platforms: Codex
- License: MIT
- Affiliation: I maintain Novel Writing. This PR was prepared with AI assistance.
- Related taxonomy issue: N/A (existing category and type).

Implementation: https://github.com/wgwtest/novel-writing/tree/main/novel-writing
Examples: https://github.com/wgwtest/novel-writing/tree/main/examples

The three original examples contain source passages, prompts, and editorial revisions. They are explicitly not benchmark results. The README documents installation, dependencies, permissions, and data-handling boundaries.

## Checklist
- [x] Public canonical implementation, documentation, and license checked.
- [x] README listings and issue/PR search checked for duplicates.
- [x] Neutral description with no volatile counts or efficacy claims.
- [x] Matching names, URLs, types, and platforms in both language versions.
- [x] Alphabetical placement between essay-writer and publora-post-ideas.
- [x] Exactly README.md and README_ZH.md changed; no implementation copied.
- [x] Affiliation disclosed; no new category or type introduced.
- [x] GitHub verifies the single commit's signature.

Validation: git diff --check; remote diff confirms two additions and zero deletions. The skill repository passes 20 tests and its 13-file package validator. An isolated installation using the official skill-installer succeeded. Cross-agent compatibility beyond Codex is not claimed.